### PR TITLE
docker-run.sh: use exec to allow matrix-qq receive signals

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -17,5 +17,5 @@ if [[ ! -f /data/registration.yaml ]]; then
 	exit
 fi
 
-cd /data
-/usr/bin/matrix-qq
+cd /data && exec /usr/bin/matrix-qq
+exit 1


### PR DESCRIPTION
现有的 docker-run.sh 会将 matrix-qq 作为子进程启动，在接收到 docker 的 `SIGTERM/SIGINT` 信号后并不会传递给 matrix-qq，导致 matrix-qq 的容器关闭均为 docker 等待超时后发送 `SIGKILL` 信号。

使用 exec 会使 sh 将自己的进程替换为 matrix-qq，docker 的信号能够直接发送到 matrix-qq